### PR TITLE
feat(gateway): migrate to spring-cloud-gateway and improve configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-gateway-mvc</artifactId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,7 +1,8 @@
 app:
+  port: ${APP_PORT:8080}
   eureka: 8761
   logging: debug
-  port: 8094
+  name: gateway-service
 
 server:
   port: ${app.port}
@@ -17,7 +18,7 @@ eureka:
 
 spring:
   application:
-    name: gateway-service
+    name: ${app.name}
   cloud:
     gateway:
       discovery:


### PR DESCRIPTION
* Replace spring-cloud-starter-gateway-mvc with spring-cloud-starter-gateway
* Add APP_PORT environment variable with default value 8080
* Centralize service name configuration in app.name property
* Update bootstrap.yml configuration to use centralized properties

BREAKING CHANGE: Default port changed from 8094 to 8080