### PR TITLE
feat: update project to Java 24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
           cache: maven
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Updated Java version from 21 to 24
+- Updated Spring Boot parent version from 3.4.0 to 3.4.4
+- Updated Spring Cloud version from 2024.0.0 to 2024.0.1
+- Updated Docker base image from eclipse-temurin:21-jre-alpine to eclipse-temurin:24-jre-alpine
+- Updated GitHub Actions workflow to use JDK 24
+- Enhanced README.md with comprehensive documentation following international standards
+
+### Added
+- New CHANGELOG.md file to track project changes
+- Detailed project documentation in README.md
+- Prerequisites section in README.md
+- Getting Started guide in README.md
+- Configuration documentation in README.md
+- API Documentation section in README.md
+- Contributing guidelines reference in README.md
+- License information in README.md
+- Support section in README.md
+- Acknowledgments section in README.md 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:24-jre-alpine
 
 # Instalar curl en la imagen
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,3 +1,81 @@
 # PyS.gateway-service
 
-[![ETEREA.gateway-service CI](https://github.com/PyS-services/PyS.gateway-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/PyS-services/PyS.gateway-service/actions/workflows/maven.yml)
+[![PyS.gateway-service CI](https://github.com/PyS-services/PyS.gateway-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/PyS-services/PyS.gateway-service/actions/workflows/maven.yml)
+
+## Overview
+
+PyS.gateway-service is a Spring Cloud Gateway service that acts as the entry point for the PyS microservices ecosystem. It provides routing, load balancing, and API gateway functionality.
+
+## Features
+
+- Dynamic routing configuration
+- Service discovery integration with Eureka
+- Load balancing
+- API gateway capabilities
+- Actuator endpoints for monitoring
+- Health checks
+
+## Prerequisites
+
+- Java 24
+- Maven 3.8+
+- Docker (optional)
+- Spring Cloud 2024.0.1
+- Spring Boot 3.4.4
+
+## Getting Started
+
+### Building the Application
+
+```bash
+mvn clean install
+```
+
+### Running the Application
+
+```bash
+mvn spring-boot:run
+```
+
+### Docker
+
+Build the Docker image:
+```bash
+docker build -t pys-gateway-service .
+```
+
+Run the container:
+```bash
+docker run -p 8080:8080 pys-gateway-service
+```
+
+## Configuration
+
+The service can be configured through the following files:
+- `application.yml` - Main configuration
+- `bootstrap.yml` - Bootstrap configuration
+
+## API Documentation
+
+The API documentation is available at:
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- OpenAPI Documentation: `http://localhost:8080/v3/api-docs`
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Support
+
+For support, please open an issue in the GitHub repository or contact the development team.
+
+## Acknowledgments
+
+- Spring Cloud Gateway
+- Spring Boot
+- Spring Cloud Netflix
+- Eclipse Temurin

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.pys.gateway</groupId>
@@ -27,8 +27,8 @@
         <url/>
     </scm>
     <properties>
-        <java.version>21</java.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <java.version>24</java.version>
+        <spring-cloud.version>2024.0.1</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
- Update Java version from 21 to 24 in pom.xml and GitHub Actions
- Update Spring Boot parent version from 3.4.0 to 3.4.4
- Update Spring Cloud version from 2024.0.0 to 2024.0.1
- Update Docker base image from eclipse-temurin:21 to 24
- Add comprehensive CHANGELOG.md following Keep a Changelog format
- Enhance README.md with detailed documentation and structure

Closes #1