### PR TITLE
feat: actualización a Java 24 y Spring Boot 3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.1-SNAPSHOT] - 2025-04-03
 
 ### Changed
-- Updated Java version from 21 to 24
-- Updated Spring Boot parent version from 3.4.0 to 3.4.4
-- Updated Spring Cloud version from 2024.0.0 to 2024.0.1
-- Updated Docker base image from eclipse-temurin:21-jre-alpine to eclipse-temurin:24-jre-alpine
-- Updated GitHub Actions workflow to use JDK 24
-- Enhanced README.md with comprehensive documentation following international standards
+- Actualizado Java de la versión 21 a 24
+- Actualizada la versión de Spring Boot de 3.4.0 a 3.5.3
+- Actualizada la versión de Spring Cloud de 2024.0.0 a 2025.0.0
+- Actualizada la imagen base de Docker a eclipse-temurin:24-jre-alpine
+- Actualizado el flujo de trabajo de GitHub Actions para usar JDK 24
+- Mejorado el README.md con documentación detallada siguiendo estándares internacionales
 
 ### Added
-- New CHANGELOG.md file to track project changes
-- Detailed project documentation in README.md
-- Prerequisites section in README.md
-- Getting Started guide in README.md
-- Configuration documentation in README.md
-- API Documentation section in README.md
-- Contributing guidelines reference in README.md
-- License information in README.md
-- Support section in README.md
-- Acknowledgments section in README.md 
+- Nuevo archivo CHANGELOG.md para realizar un seguimiento de los cambios del proyecto
+- Documentación detallada del proyecto en README.md
+- Sección de requisitos previos en README.md
+- Guía de inicio rápido en README.md
+- Documentación de configuración en README.md
+- Sección de Documentación de la API en README.md
+- Referencia a las pautas de contribución en README.md
+- Información de licencia en README.md
+- Sección de soporte en README.md
+- Sección de agradecimientos en README.md
+
+## [0.0.1-SNAPSHOT] - 2024-12-14
+
+### Changed
+- Migrado de spring-cloud-starter-gateway-mvc a spring-cloud-starter-gateway
+- Cambiado el puerto predeterminado de 8094 a 8080
+- Centralizada la configuración del nombre de la aplicación en la propiedad app.name
+- Actualizado bootstrap.yml para usar propiedades centralizadas
+
+### Breaking Changes
+- Cambio de puerto predeterminado de 8094 a 8080
+
+## [0.0.1-SNAPSHOT] - 2024-12-06
+
+### Changed
+- Actualizada la versión de Spring Boot a 3.4.0
+- Actualizada la versión de Spring Cloud a 2024.0.0
+- Actualizada la versión de Springdoc a 2.7.0
+
+## [0.0.1-SNAPSHOT] - 2024-11-23
+
+### Added
+- Agregado el servicio común
+
+## [0.0.1-SNAPSHOT] - 2024-11-17
+
+### Changed
+- Actualización de versiones de dependencias

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,11 +1,11 @@
-FROM maven:3-eclipse-temurin-21-alpine AS build
+FROM maven:3-eclipse-temurin-24-alpine AS build
 ENV HOME=/usr/app
 RUN mkdir -p $HOME
 WORKDIR $HOME
 ADD . $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -f $HOME/pom.xml clean package
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:24-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ PyS.gateway-service is a Spring Cloud Gateway service that acts as the entry poi
 - Java 24
 - Maven 3.8+
 - Docker (optional)
-- Spring Cloud 2024.0.1
-- Spring Boot 3.4.4
+- Spring Cloud 2025.0.0
+- Spring Boot 3.5.3
 
 ## Getting Started
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.4</version>
+        <version>3.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.pys.gateway</groupId>
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>24</java.version>
-        <spring-cloud.version>2024.0.1</spring-cloud.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-gateway</artifactId>
+            <artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -57,6 +57,18 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-spring-boot-starter</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -64,6 +76,13 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <version>2.16.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/pys/gateway/config/GatewayConfiguration.java
+++ b/src/main/java/com/pys/gateway/config/GatewayConfiguration.java
@@ -1,4 +1,4 @@
-package com.pys.gateway.configuration;
+package com.pys.gateway.config;
 
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -21,26 +21,28 @@ spring:
     name: ${app.name}
   cloud:
     gateway:
-      discovery:
-        locator:
-          enabled: true
-      routes:
-        - id: core-service
-          uri: lb://core-service
-          predicates:
-            - Path=/api/core/**
-        - id: common-service
-          uri: lb://common-service
-          predicates:
-            - Path=/api/common-service/**
-        - id: report-service
-          uri: lb://report-service
-          predicates:
-            - Path=/api/report/**
-        - id: pyafipws-service
-          uri: lb://pyafipws-service
-          predicates:
-            - Path=/api/afipws/**
+      server:
+        webflux:
+          discovery:
+            locator:
+              enabled: true
+          routes:
+            - id: core-service
+              uri: lb://core-service
+              predicates:
+                - Path=/api/core/**
+            - id: common-service
+              uri: lb://common-service
+              predicates:
+                - Path=/api/common-service/**
+            - id: report-service
+              uri: lb://report-service
+              predicates:
+                - Path=/api/report/**
+            - id: pyafipws-service
+              uri: lb://pyafipws-service
+              predicates:
+                - Path=/api/afipws/**
 
 logging:
   level:
@@ -48,6 +50,17 @@ logging:
     web: ${app.logging}
     org:
       springframework.cloud.config: ${app.logging}
+      springframework.cloud.gateway: ${app.logging}
+      springframework.web: ${app.logging}
+      springframework.http: ${app.logging}
+      springframework.web.reactive: ${app.logging}
+      springframework.web.server: ${app.logging}
+      springframework.boot.actuate: ${app.logging}
+      springframework.cloud.netflix: ${app.logging}
+      springframework.cloud.loadbalancer: ${app.logging}
+    reactor:
+      netty: ${app.logging}
+    netty: ${app.logging}
 
 management:
   endpoints:


### PR DESCRIPTION
## Descripción

Este PR incluye la actualización de las dependencias principales del proyecto:

- **Java 21 → 24**
- **Spring Boot 3.4.4 → 3.5.3**
- **Spring Cloud 2024.0.1 → 2025.0.0**

### Cambios principales

1. **Actualización de dependencias**:
   - Agregadas nuevas dependencias para validación, caché y monitoreo
   - Actualizadas las versiones de las dependencias principales

2. **Refactorización**:
   - Reorganizada la estructura de paquetes ( → )
   - Actualizada la configuración para usar WebFlux
   - Mejorada la configuración de logging

3. **Docker**:
   - Actualizada la imagen base a 
   - Ajustada la configuración para Java 24

### Impacto potencial

- **Cambios rompedores**:
  - Se requiere JDK 24 para compilar
  - Cambios en la estructura de configuración de rutas
  - Cambio en el paquete de configuración

### Pruebas recomendadas

- [ ] Verificar el arranque de la aplicación
- [ ] Validar las rutas del API Gateway
- [ ] Comprobar el monitoreo con OpenTelemetry

### Notas adicionales

- Se recomienda actualizar el entorno de CI/CD para usar Java 24
- Verificar la compatibilidad con servicios dependientes

Resuelve #16